### PR TITLE
AP-576 add retry policy enabled

### DIFF
--- a/Source/CurrencyCloud/CurrencyCloud.csproj
+++ b/Source/CurrencyCloud/CurrencyCloud.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>0.0.123</PackageVersion>
+    <PackageVersion>0.0.124</PackageVersion>
     <PackageId>ApprovalMax.CurrencyCloud</PackageId>
     <AssemblyName>ApprovalMax.CurrencyCloud</AssemblyName>
     <RootNamespace>CurrencyCloud</RootNamespace>
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ApprovalMax.Ensure.That" Version="0.0.0.105" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="7.2.4" />

--- a/Source/CurrencyCloud/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Source/CurrencyCloud/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using CurrencyCloud.Authorization;
+using CurrencyCloud.Options;
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+using CurrencyCloudClient = CurrencyCloud.Client;
+
+namespace CurrencyCloud.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddCurrencyCloudClient(
+        this IServiceCollection serviceCollection,
+        CurrencyCloudOptions options)
+    {
+        EnsureArg.IsNotNull(serviceCollection);
+        EnsureArg.IsNotNull(options);
+        EnsureArg.IsNotNullOrWhiteSpace(options.LoginId);
+        EnsureArg.IsNotNullOrWhiteSpace(options.ApiKey);
+
+        serviceCollection.AddSingleton(
+            new AuthorizationOptions(new Credentials(options.LoginId, options.ApiKey), options.TokenLifetime));
+
+        serviceCollection.AddSingleton<IAuthorizationService, AuthorizationService>();
+
+        serviceCollection.AddHttpClient<AuthorizationService>(
+                client =>
+                {
+                    client.BaseAddress = new Uri(options.ApiServer.Url);
+                    client.Timeout = options.Timeout;
+                })
+            .ConfigurePrimaryHttpMessageHandler(
+                () => new SocketsHttpHandler
+                {
+                    PooledConnectionLifetime = options.PooledConnectionLifetime
+                })
+            .SetHandlerLifetime(Timeout.InfiniteTimeSpan);
+
+        serviceCollection
+            .AddScoped<ICurrencyCloudClient, CurrencyCloudClient>();
+
+        serviceCollection
+            .AddHttpClient<CurrencyCloudClient>()
+            .ConfigureHttpClient(
+                (_, client) =>
+                {
+                    client.BaseAddress = new Uri(options.ApiServer.Url);
+                    client.Timeout = options.Timeout;
+                })
+            .ConfigurePrimaryHttpMessageHandler(
+                () => new SocketsHttpHandler
+                {
+                    PooledConnectionLifetime = options.PooledConnectionLifetime
+                })
+            .SetHandlerLifetime(Timeout.InfiniteTimeSpan);
+
+        Retry.Enabled = true;
+        
+        return serviceCollection;
+    }
+}

--- a/Source/CurrencyCloud/Options/CurrencyCloudOptions.cs
+++ b/Source/CurrencyCloud/Options/CurrencyCloudOptions.cs
@@ -1,0 +1,24 @@
+using System;
+using CurrencyCloud.Environment;
+
+namespace CurrencyCloud.Options;
+
+public sealed record CurrencyCloudOptions
+{
+    public ApiServer ApiServer => ApiServerFromString(this.ApiServerIdentifier);
+    public required string LoginId { get; init; }
+    public required string ApiKey { get; init; }
+    public required TimeSpan TokenLifetime { get; init; }
+    public required TimeSpan Timeout { get; init; }
+    public required TimeSpan PooledConnectionLifetime { get; init; }
+
+    private string ApiServerIdentifier { get; init; } = null!;
+
+    private static ApiServer ApiServerFromString(string apiServer) => apiServer switch
+    {
+        "Demo" => ApiServer.Demo,
+        "Production" => ApiServer.Production,
+        "Mock" => ApiServer.Mock,
+        _ => throw new ArgumentException("Invalid ApiServer specified")
+    };
+}


### PR DESCRIPTION
add retry policy enabled (ServiceCollectionExtensions line 59: Retry.Enabled = true;)
moving initialization to currency cloud repo

about implemented retry mechanism you can read here:
[retry in currency cloud](https://github.com/CurrencyCloud/currencycloud-net?tab=readme-ov-file#exponential-backoff--retry-strategy)

I tested it locally with localhost mock api, it works as intended